### PR TITLE
Improve user-friendliness

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -150,7 +150,7 @@ minetest.register_chatcommand("vote", {
 		basic_vote.vote.type = tonumber(paramt[1]);
 		basic_vote.vote.name=paramt[2] or "an unknown player";
 		basic_vote.vote.voter = name;
-		basic_vote.vote.reason = paramt[3]
+		basic_vote.vote.reason = string.match(param, "%w+ [%w_-]+ (.+)")
 		basic_vote.vote.votes_needed =  basic_vote.types[ basic_vote.vote.type ][2];
 		basic_vote.vote.timeout = basic_vote.types[ basic_vote.vote.type ][3];
 		

--- a/init.lua
+++ b/init.lua
@@ -5,14 +5,14 @@ local basic_vote = {};
 -- SETTINGS ----------------------------------------------------------------------
 
 -- DEFINE VOTE TYPES
-basic_vote.types = { -- [type] = { description , votes_needed , timeout}
+basic_vote.types = { -- [type] = { description , votes_needed , timeout, command, help_description}
 
-[0] = {"ban for 2 minutes" , -3 , 30},                -- -3 means strictly more than 3 players need to vote ( so 4 or more)
-[1] = {"remove interact of" , 0.5, 120}, -- 0.5 means at least 50% need to vote
-[2] = {"give interact to" , 0.5 , 120},
-[3] = {"kill" , -3 , 30},
-[4] = {"poison" , -3 , 30},
-[5] = {"teleport to me" , -3 , 30},
+[1] = {"remove interact of %s" , 0.5, 120, "remove_interact", "Remove “interact” privilege from player"}, -- 0.5 means at least 50% need to vote
+[2] = {"give interact to %s" , 0.5 , 120, "give_interact", "Give “interact” privilege to player"},
+[3] = {"kill %s" , -3 , 30, "kill", "Kill player"},
+[4] = {"poison %s" , -3 , 30, "poison", "Poison player"},
+[5] = {"teleport %s to vote starter" , -3 , 30, "teleport", "Teleport player to you"},
+[6] = {"ban %s for 2 minutes" , -3 , 30, "ban", "Ban player for 2 minutes"},                -- -3 means strictly more than 3 players need to vote ( so 4 or more)
 };
 basic_vote.modreq = 2; -- more that this number of moderators from "anticheat" mod must vote for mod to succeed
 
@@ -94,7 +94,7 @@ minetest.register_on_prejoinplayer(
 			if t>120 then 
 				basic_vote.kicklist[ip] = nil;
 			else
-				return "You have been banned from the server."
+				return "You have been temporarily banned from the server."
 			end
 		end
 		
@@ -114,20 +114,27 @@ basic_vote.vote = {time = 0,type = 0, name = "", reason = "", votes_needed = 0, 
 
 
 basic_vote.requirements = {[0]=0}
-basic_vote.vote_desc=""; for i,v in pairs(basic_vote.types) do basic_vote.vote_desc = basic_vote.vote_desc .. " type ".. i .. ": ".. v[1]..", " end
-
+basic_vote.vote_desc=""
+for i=1,#basic_vote.types do
+	basic_vote.vote_desc = basic_vote.vote_desc .. "Type ".. i .. ": ".. basic_vote.types[i][5].."\n"
+end
 
 -- starts a new vote
 minetest.register_chatcommand("vote", { 
 	privs = {
 		interact = true
 	},
+	params = "[[<type> <name> [<reason>]] | types]",
+	description = "Start a vote. “/vote types” for a list of types, “/vote” without arguments to see current voting progress",
 	func = function(name, param)
 		
 		if basic_vote.state~=0 then 
-			minetest.chat_send_player(name,"vote already in progress:") 
+			minetest.chat_send_player(name,"Vote already in progress:") 
 			minetest.chat_send_player(name,basic_vote.vote.description);
 			return 
+		elseif param == "" then
+			minetest.chat_send_player(name,"No vote in progress.")
+			return
 		end
 		local player = minetest.get_player_by_name(name);
 		
@@ -136,11 +143,12 @@ minetest.register_chatcommand("vote", {
 		for i = #paramt+1,3 do paramt[i]="" end
 		
 		
-		if not basic_vote.types[ tonumber(paramt[1]) ] then minetest.chat_send_player(name,"USAGE: vote type name reason, "..basic_vote.vote_desc) return end
+		if paramt[1] == "types" then minetest.chat_send_player(name, basic_vote.vote_desc) return end
+		if not basic_vote.types[ tonumber(paramt[1]) ] then minetest.chat_send_player(name,"Error: Invalid syntax or type. Use “/help vote” for help.") return end
 		
 		basic_vote.vote.time = minetest.get_gametime();
 		basic_vote.vote.type = tonumber(paramt[1]);
-		basic_vote.vote.name=paramt[2] or "";
+		basic_vote.vote.name=paramt[2] or "an unknown player";
 		basic_vote.vote.voter = name;
 		basic_vote.vote.reason = paramt[3]
 		basic_vote.vote.votes_needed =  basic_vote.types[ basic_vote.vote.type ][2];
@@ -148,21 +156,33 @@ minetest.register_chatcommand("vote", {
 		
 		
 		--check if target valid player
-		if not minetest.get_player_by_name(basic_vote.vote.name) and basic_vote.vote.type~= 1 then return end
+		if basic_vote.vote.name == "" then
+			minetest.chat_send_player(name,"Error: No player specified.")
+			return
+		elseif not minetest.get_player_by_name(basic_vote.vote.name) and basic_vote.vote.type~= 1 then
+			minetest.chat_send_player(name,"Error: The specified player is currently not connected.")
+			return
+		end
 		
 		-- check anticheat db
 		local ip = tostring(minetest.get_player_ip(basic_vote.vote.name));
 		if anticheatdb and anticheatdb[ip] then -- #anticheat mod: makes detected cheater more succeptible to voting
 			if anticheatsettings.moderators[name] then -- moderator must call vote
 				basic_vote.vote.votes_needed=0; -- just need 1 vote
-				name = "#anticheat"; -- so cheater does not see who voted - anonymous vote
+				name = "an anonymous player"; -- so cheater does not see who voted - anonymous vote
 			end
 		end
 		
 		basic_vote.votes = 0; basic_vote.modscore = 0; basic_vote.voters = {};
 		
-		basic_vote.vote.description = "## VOTE (by ".. name ..") to ".. (basic_vote.types[basic_vote.vote.type][1] or "") .. " " .. (basic_vote.vote.name or "") .. " because " .. (basic_vote.vote.reason or "").. " ##\nsay /y to vote. Timeout in ".. basic_vote.vote.timeout  .. "s.";
-		
+		local type_str = string.format(basic_vote.types[basic_vote.vote.type][1], basic_vote.vote.name)
+
+		if basic_vote.vote.reason == nil or basic_vote.vote.reason == "" then
+			basic_vote.vote.description = string.format("## VOTE started (by %s to %s).\nSay “/y” to vote “yes”. Timeout in %ds.", name, type_str, basic_vote.vote.timeout)
+		else
+			basic_vote.vote.description = string.format("## VOTE started (by %s to %s) with reason: “%s”.\nSay “/y” to vote “yes”. Timeout in %ds.", name, type_str, basic_vote.vote.reason, basic_vote.vote.timeout)
+		end
+
 		minetest.chat_send_all(basic_vote.vote.description);
 		basic_vote.state = 1; minetest.after(basic_vote.vote.timeout, function() 
 			if basic_vote.state == 1 then basic_vote.state = 2;basic_vote.update(); end
@@ -189,7 +209,7 @@ basic_vote.update = function()
 	end
 	
 	if basic_vote.state == 2 then -- timeout
-		minetest.chat_send_all("##VOTE failed. ".. basic_vote.votes .." voted (needed more than ".. votes_needed ..")");
+		minetest.chat_send_all("## VOTE failed. ".. basic_vote.votes .." voted (needed more than ".. votes_needed ..").");
 		basic_vote.state = 0;basic_vote.vote = {time = 0,type = 0, name = "", reason = ""}; return 
 	end
 	if basic_vote.state~=1 then return end -- no vote in progress
@@ -201,7 +221,7 @@ basic_vote.update = function()
 	end
 	
 	if basic_vote.votes>votes_needed then  -- enough voters
-		minetest.chat_send_all("##VOTE succeded. "..basic_vote.votes .." voted ");
+		minetest.chat_send_all("## VOTE succeded. "..basic_vote.votes .." voted.");
 		local type = basic_vote.vote.type;
                 basic_vote.execute(basic_vote.vote.type,basic_vote.vote.name, basic_vote.vote.reason)
 		basic_vote.state = 0;basic_vote.vote = {time = 0,type = 0, name = "", reason = ""};
@@ -210,21 +230,33 @@ basic_vote.update = function()
 end
 
 local cast_vote = function (name,param)
-	if basic_vote.state~=1 then return end -- vote not in progress
+	if basic_vote.state~=1 then
+		-- vote not in progress
+		minetest.chat_send_player(name,"Error: No vote in progress.");
+		return
+	end
 		local ip = tostring(minetest.get_player_ip(name));
-		if basic_vote.voters[ip] then return else basic_vote.voters[ip]=true end -- mark as already voted
+		if basic_vote.voters[ip] then
+			minetest.chat_send_player(name,"Error: You already voted.");
+			return
+		else
+			-- mark as already voted
+			basic_vote.voters[ip]=true
+		end
 		basic_vote.votes = basic_vote.votes+1;
 		if anticheatsettings and anticheatsettings.moderators[name] then -- moderator from anticheat mod
 			basic_vote.modscore=basic_vote.modscore+1;
 		end
 		local privs = core.get_player_privs(name);if privs.kick then basic_vote.votes = 100; end
-		basic_vote.update(); minetest.chat_send_player(name,"vote received");
+		basic_vote.update(); minetest.chat_send_player(name,"Vote received.");
 end
 
 minetest.register_chatcommand("y", { 
 	privs = {
 		interact = true
 	},
+	params = "",
+	description = "Vote “Yes.” in the current vote (see vote command)",
 	func = function(name, param)
 		cast_vote(name,param)
 	end

--- a/init.lua
+++ b/init.lua
@@ -116,7 +116,7 @@ basic_vote.vote = {time = 0,type = 0, name = "", reason = "", votes_needed = 0, 
 basic_vote.requirements = {[0]=0}
 basic_vote.vote_desc=""
 for i=1,#basic_vote.types do
-	basic_vote.vote_desc = basic_vote.vote_desc .. "Type ".. i .. ": ".. basic_vote.types[i][5].."\n"
+	basic_vote.vote_desc = basic_vote.vote_desc .. "Type " .. i .. " (" ..basic_vote.types[i][4].. "): ".. basic_vote.types[i][5].."\n"
 end
 
 -- starts a new vote
@@ -144,10 +144,19 @@ minetest.register_chatcommand("vote", {
 		
 		
 		if paramt[1] == "types" then minetest.chat_send_player(name, basic_vote.vote_desc) return end
-		if not basic_vote.types[ tonumber(paramt[1]) ] then minetest.chat_send_player(name,"Error: Invalid syntax or type. Use “/help vote” for help.") return end
 		
 		basic_vote.vote.time = minetest.get_gametime();
 		basic_vote.vote.type = tonumber(paramt[1]);
+		-- check for text-based types
+		if basic_vote.vote.type == nil then
+			for i=1,#basic_vote.types do
+				if paramt[1] == basic_vote.types[i][4] then
+					basic_vote.vote.type = i
+				end
+			end
+		end
+		if not basic_vote.vote.type then minetest.chat_send_player(name,"Error: Invalid syntax or type. Use “/help vote” for help.") return end
+
 		basic_vote.vote.name=paramt[2] or "an unknown player";
 		basic_vote.vote.voter = name;
 		basic_vote.vote.reason = string.match(param, "%w+ [%w_-]+ (.+)")


### PR DESCRIPTION
This PR makes the mod a bit more user-friendly.
- Add basic description/syntax reference for chat commands (i.e. `/help vote` now works)
- More helpful error messages
- More helpful messages
- Rewrite most strings
- Allow to write spaces in reason
- Add alternative way to specify type in string format
- Start type counting with 1 (Lua convention)
- Less confusing output for querying current votes
- Fix incorrect timeout being displayed when querying current vote
